### PR TITLE
Fix: panic in dubbo-go-samples/game path

### DIFF
--- a/cmd/imports-formatter/main.go
+++ b/cmd/imports-formatter/main.go
@@ -218,7 +218,7 @@ func doReformat(filePath string) error {
 			} else {
 				// imports of the third projects
 				importsSegment := strings.Split(importKey, "/")
-				project := strings.Join(importsSegment[:3], "/")
+				project := strings.Join(importsSegment[:len(importsSegment) - 1], "/")
 				cacheImports(thirdImports, project, orgImportPkg)
 			}
 		}


### PR DESCRIPTION
在调整 game 目录的 imports 的时候出现了 panic
![image](https://user-images.githubusercontent.com/23278645/125187478-6f7bf880-e262-11eb-98c1-f17574969be7.png)
现在已经修复